### PR TITLE
Rename title and key terms to broaden the scope of the Best Practices

### DIFF
--- a/main.adoc
+++ b/main.adoc
@@ -1,6 +1,6 @@
 [id="cnf-best-practices"]
-= CNF Best Practices
-Cloud-native network functions (CNFs) best practices
+= Red Hat Best Practices for Kubernetes
+Workload best practices
 :revnumber: v2
 :revdate: 2023
 :toc: left

--- a/modules/cnf-best-practices-affinity-anti-affinity.adoc
+++ b/modules/cnf-best-practices-affinity-anti-affinity.adoc
@@ -27,7 +27,7 @@ spec:
       image: docker.io/ocpqe/hello-pod
 ----
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Pods that need to be co-located on the same node need affinity rules. Pods that should not be
@@ -36,7 +36,7 @@ co-located for resiliency purposes require anti-affinity rules.
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#lifecycle-affinity-required-pods[lifecycle-affinity-required-pods]
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Pods that perform the same microservice and could be disrupted if multiple members of the service are

--- a/modules/cnf-best-practices-analyzing-your-application.adoc
+++ b/modules/cnf-best-practices-analyzing-your-application.adoc
@@ -1,6 +1,6 @@
 [id="cnf-best-practices-analyzing-your-application"]
 = Analyzing your application
 
-To find out which capabilities the application needs, Red Hat has developed a SystemTap script (`container_check.stp`). With this tool, the CNF developer can find out what capabilities an application requires in order to run in a container. It also shows the syscalls which were invoked. Find more info at link:https://linuxera.org/capabilities-seccomp-kubernetes/[]
+To find out which capabilities the application needs, Red Hat has developed a SystemTap script (`container_check.stp`). With this tool, the workload developer can find out what capabilities an application requires in order to run in a container. It also shows the syscalls which were invoked. Find more info at link:https://linuxera.org/capabilities-seccomp-kubernetes/[]
 
 Another tool is `capable` which is part of the BCC tools. It can be installed on RHEL8 with `dnf install bcc`.

--- a/modules/cnf-best-practices-avoid-the-host-network-namespace.adoc
+++ b/modules/cnf-best-practices-avoid-the-host-network-namespace.adoc
@@ -3,7 +3,7 @@
 
 Application pods must avoid using `hostNetwork`. Applications may not use the host network, including `nodePort` for network communication. Any networking needs beyond the functions provided by the pod network and ingress/egress proxy must be serviced via a MULTUS connected interface.
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Applications may not use `NodePorts` or the `hostNetwork`.

--- a/modules/cnf-best-practices-cloud-native-design-best-practices.adoc
+++ b/modules/cnf-best-practices-cloud-native-design-best-practices.adoc
@@ -28,7 +28,7 @@ A corollary of this practice is to "retry instead of crashing", for example, Whe
 +
 Also related to this, by default containers are launched with shared images using COW filesystems which only exist as long as the container exists. Mounting Persistent Volume Claims enables a container to have persistent physical storage. Clearly defining the abstraction for what storage is persisted promotes the idea that instances are disposable.
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Application design should conform to cloud-native design principles to the maximum extent possible.

--- a/modules/cnf-best-practices-cnf-operator-requirements.adoc
+++ b/modules/cnf-best-practices-cnf-operator-requirements.adoc
@@ -1,7 +1,7 @@
 [id="cnf-best-practices-cnf-operator-requirements"]
-= CNF Operator requirements
+= Workload Operator requirements
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Operators should be certified against the openshift version of the cluster they will be deployed on.
@@ -9,7 +9,7 @@ Operators should be certified against the openshift version of the cluster they 
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#affiliated-certification-operator-is-certified[affiliated-certification-operator-is-certified]
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Operators must be compatible with our version of openshift
@@ -21,7 +21,7 @@ Operators must be compatible with our version of openshift
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#platform-alteration-ocp-lifecycle[platform-alteration-ocp-lifecycle]
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Operators must be in OLM bundle format (Operator Framework).
@@ -29,19 +29,19 @@ Operators must be in OLM bundle format (Operator Framework).
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#operator-install-source[operator-install-source]
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Must be able to function without the use of openshift routes or ingress objects.
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 All custom resources for operators require podspecs for both pod image override as well pod quotas.
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Operators must not use daemonsets
@@ -49,25 +49,25 @@ Operators must not use daemonsets
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#lifecycle-pod-owner-type[lifecycle-pod-owner-type]
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
-The OLM operator CSV must support the "all namespaces" install method if the operator is upstream software. If the operator is a proprietary cnf operator it must support single namespaced installation. It is recommended for an operator to support all OLM install modes to ensure flexibility in our environment.
+The OLM operator CSV must support the "all namespaces" install method if the operator is upstream software. If the operator is a proprietary workload operator it must support single namespaced installation. It is recommended for an operator to support all OLM install modes to ensure flexibility in our environment.
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 The operator must default to watch all namespaces if the target namespace is left NULL or empty string as this is how the OLM global-operators operator group functions.
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 All operator and operand images must be referenced using digest image tags "@sha256". Openshift "imagecontentsourcepolicy" objects (ICSP) only support mirror-by-digest at this time.
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 For general third party upstream operators (example: mongodb), the OLM package is recommended to be located within the Red Hat registries below to support our image mirror policy:
@@ -81,21 +81,21 @@ For general third party upstream operators (example: mongodb), the OLM package i
 * `registry.access.redhat.com`
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
-Operators that are proprietary to a cnf application must ensure that their CRD's are unique, and will not conflict with other operators in the cluster.
+Operators that are proprietary to a workload application must ensure that their CRD's are unique, and will not conflict with other operators in the cluster.
 
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#observability-crd-status[observability-crd-status]
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
-If a cnf application requires a specific version of a third party non-proprietary operator for their app to function they will need to re-package the upstream third party operator and modify the APIs so that it will not conflict with the globally installed operator version.
+If a workload application requires a specific version of a third party non-proprietary operator for their app to function they will need to re-package the upstream third party operator and modify the APIs so that it will not conflict with the globally installed operator version.
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Successful operator installation and runtime must be validated in pre-deployment lab environments before being allowed to be deployed to production.
@@ -103,14 +103,14 @@ Successful operator installation and runtime must be validated in pre-deployment
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#operator-install-status-succeeded[operator-install-status-succeeded]
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 All required RBAC must be included in the OLM operator bundle so that it's managed by OLM.
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
-It is not recommended for a cnf application to share a proprietary operator with another cnf application if that application does not share the same version lifecycle. If a cnf application does share an operator the CRDs must be backwards compatible.
+It is not recommended for a workload application to share a proprietary operator with another workload application if that application does not share the same version lifecycle. If a workload application does share an operator the CRDs must be backwards compatible.
 ====

--- a/modules/cnf-best-practices-cnf-securing-cnf-networks.adoc
+++ b/modules/cnf-best-practices-cnf-securing-cnf-networks.adoc
@@ -1,9 +1,9 @@
 [id="cnf-best-practices-cnf-securing-cnf-networks"]
-= Securing CNF networks
+= Securing workload networks
 
-CNFs must have the least permissions possible and CNFs must implement Network Policies that drop all traffic by default and permit only the relevant ports and protocols to the narrowest ranges of addresses possible.
+Workloads must have the least permissions possible and must implement Network Policies that drop all traffic by default and permit only the relevant ports and protocols to the narrowest ranges of addresses possible.
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Applications must define network policies that permit only the minimum network access the application needs to function.

--- a/modules/cnf-best-practices-cnf-security.adoc
+++ b/modules/cnf-best-practices-cnf-security.adoc
@@ -1,5 +1,5 @@
 [id="cnf-best-practices-cnf-security"]
-= CNF security
+= Workload security
 
 In OCP, it is possible to run privileged containers that have all of the root capabilities on a host machine, allowing the ability to access resources which are not accessible in ordinary containers. This, however, increases the security risk to the whole cluster. Containers should only request those privileges they need to run their legitimate functions. No containers will be allowed to run with full privileges without an exception.
 
@@ -7,13 +7,13 @@ The general guidelines are:
 
 . Only ask for the necessary privileges and access control settings for your application.
 
-. If the function required by your CNF can be fulfilled by OCP components, your application should not be requesting escalated privilege to perform this function.
+. If the function required by your workload can be fulfilled by OCP components, your application should not be requesting escalated privilege to perform this function.
 
 . Avoid using any host system resource if possible.
 
 . Leveraging read only root filesystem when possible.
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Only ask for the necessary privileges and access control settings for your application
@@ -21,16 +21,16 @@ Only ask for the necessary privileges and access control settings for your appli
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#access-control-security-context-non-root-user-check[access-control-security-context-non-root-user-check]
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
-If the function required by your CNF can be fulfilled by OCP components, your application should not be
+If the function required by your workload can be fulfilled by OCP components, your application should not be
 requesting escalated privilege to perform this function.
 
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#access-control-security-context-privilege-escalation[access-control-security-context-privilege-escalation]
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Avoid using any host system resource.
@@ -39,7 +39,7 @@ See test cases link:https://github.com/test-network-function/cnf-certification-t
 link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#access-control-pod-host-pid[access-control-pod-host-pid]
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Do not mount host directories for device access.
@@ -47,7 +47,7 @@ Do not mount host directories for device access.
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#access-control-pod-host-path[access-control-pod-host-path]
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Do not use host network namespace.
@@ -55,10 +55,10 @@ Do not use host network namespace.
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#access-control-namespace[access-control-namespace]
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
-CNFs may not modify the platform in any way.
+Workloads may not modify the platform in any way.
 
 See test cases link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#platform-alteration-base-image[platform-alteration-base-image], link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#platform-alteration-sysctl-config[platform-alteration-sysctl-config]
 ====

--- a/modules/cnf-best-practices-cpu-isolation.adoc
+++ b/modules/cnf-best-practices-cpu-isolation.adoc
@@ -5,7 +5,7 @@ The Node Tuning Operator manages host CPUs by dividing them into reserved CPUs f
 
 Device interrupts are load balanced between all isolated and reserved CPUs to avoid CPUs being overloaded, with the exception of CPUs where there is a guaranteed pod running. Guaranteed pod CPUs are prevented from processing device interrupts when the relevant annotations are set for the pod.
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 To use isolated CPUs, specific annotations must be defined in the pod specification.

--- a/modules/cnf-best-practices-cpu-manager-pinning.adoc
+++ b/modules/cnf-best-practices-cpu-manager-pinning.adoc
@@ -3,12 +3,12 @@
 
 The OpenShift platform can use the Kubernetes CPU Manager to support CPU pinning for applications.
 
-Important note on using probes: If the CNF is doing CPU pinning and running a DPDK process do
+Important note on using probes: If the workload is doing CPU pinning and running a DPDK process do
 not use exec probes (executing a command within the container) as it may pile up and block the
 node eventually.
 
 
-CNF Requirement: If a CNF is doing CPU pinning, exec probes may not be used.
+Workload Requirement: If a workload is doing CPU pinning, exec probes may not be used.
 
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#networking-dpdk-cpu-pinning-exec-probe[networking-dpdk-cpu-pinning-exec-probe]
 

--- a/modules/cnf-best-practices-csi.adoc
+++ b/modules/cnf-best-practices-csi.adoc
@@ -5,7 +5,7 @@ Pod volumes are supported via local storage and the CSI for persistent volumes. 
 
 When using storage with Kubernetes, you can use storage classes. Refer to <<cnf-best-practices-block-storage>> for a description of the available storage classes. Using storage classes, you can create volumes based on the parameters of the required storage.
 
-Network functions should clear persistent storage by deleting the associated `PV` resources when removing the application from a cluster.
+Workloads should clear persistent storage by deleting the associated `PV` resources when removing the application from a cluster.
 
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#lifecycle-persistent-volume-reclaim-policy[lifecycle-persistent-volume-reclaim-policy]
 

--- a/modules/cnf-best-practices-custom-role-to-access-application-crds.adoc
+++ b/modules/cnf-best-practices-custom-role-to-access-application-crds.adoc
@@ -3,7 +3,7 @@
 
 If an application requires installing/deploying CRDs (Custom Resource Definitions), the application must provide a role that allows necessary permissions to create CRs within the CRDs. The custom role to access CRDs must not create any permissions to access any other API resources than the CRDs.
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 If an application creates CRDs; it must supply a role to access those CRDs and no other API resources/

--- a/modules/cnf-best-practices-developer-guide.adoc
+++ b/modules/cnf-best-practices-developer-guide.adoc
@@ -1,19 +1,19 @@
 [id="cnf-best-practices-developer-guide"]
-= CNF developer guide
+= Workload developer guide
 
-This section discusses recommendations and requirements for CNF application builders.
+This section discusses recommendations and requirements for workload application builders.
 
 [id="cnf-best-practices-preface"]
 == Preface
 
-Cloud-native Network Functions (CNFs) are containerized instances of classic physical or virtual network functions (VNF) which have been decomposed into microservices supporting elasticity, lifecycle management, security, logging, and other capabilities in a Cloud-Native format.
+Cloud-native workload applications are containerized instances of classic physical or virtual applications which have been decomposed into microservices supporting elasticity, lifecycle management, security, logging, and other capabilities in a Cloud-Native format.
 
 [id="cnf-best-practices-goal"]
 == Goal
 
-This document is mainly for the developers of CNFs, who need to build high-performance Network Functions in a containerized environment. We have created a guide that any partner can take and follow when developing their CNFs so that they can be deployed on the OpenShift Container Platform (OCP) in a secure, efficient and supportable way.
+This document is mainly for the developers of workloads, who need to build high-performance applications in a containerized environment. We have created a guide that any partner can take and follow when developing their workloads so that they can be deployed on the OpenShift Container Platform (OCP) in a secure, efficient and supportable way.
 
 [id="cnf-best-practices-non-goal"]
 == Non-goal
 
-This is not a guide on how to build CNF functionality.
+This is not a guide on how to build workload functionality.

--- a/modules/cnf-best-practices-ephemeral-storage.adoc
+++ b/modules/cnf-best-practices-ephemeral-storage.adoc
@@ -3,7 +3,7 @@
 
 Pods and containers can require ephemeral or transient local storage for their operation. The lifetime of this ephemeral storage does not extend beyond the life of the individual pod, and this ephemeral storage cannot be shared across pods.
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Pods must not place persistent data in ephemeral storage.

--- a/modules/cnf-best-practices-foreword.adoc
+++ b/modules/cnf-best-practices-foreword.adoc
@@ -1,8 +1,8 @@
 [id="cnf-best-practices-foreword"]
 = Foreword
 
-This Cloud Native Function (CNF) requirements document was originally created in 2020 by Verizon with assistance from Red Hat.
-Verizon's vision of an open collaborative process to create industry standards for cloud-native network functions led this document to be where it is today.
+This _Red Hat Best Practices for Kubernetes_ document was originally created in 2020 by Verizon with assistance from Red Hat.
+Verizon's vision of an open collaborative process to create industry standards for cloud-native workloads led this document to be where it is today.
 Over many iterations, and based on lessons learned and feature improvements in the areas of security, lifecycle management, networking, and many other components, the document has matured into its current state.
 
 Many thanks to the team at Verizon for kick-starting this effort and for the many contributions Verizon has made to the document over the years.

--- a/modules/cnf-best-practices-graceful-termination.adoc
+++ b/modules/cnf-best-practices-graceful-termination.adoc
@@ -7,7 +7,7 @@ When pods are shut down by the platform they are sent a `SIGTERM` signal which m
 
 Pods should exit with zero exit codes when they are gracefully terminated.
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 All pods must respond to SIGTERM signal and shutdown gracefully with a zero exit code.

--- a/modules/cnf-best-practices-helm.adoc
+++ b/modules/cnf-best-practices-helm.adoc
@@ -6,7 +6,7 @@ Helm is roughly analogous to HEAT templates in the OpenStack environment.
 
 For more information, see link:https://docs.openshift.com/container-platform/latest/applications/working_with_helm_charts/understanding-helm.html[Understanding Helm].
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 If you use Helm to deploy your application, you must use Helm v3 because of security issues with Helm v2.

--- a/modules/cnf-best-practices-high-level-cnf-expectations.adoc
+++ b/modules/cnf-best-practices-high-level-cnf-expectations.adoc
@@ -1,7 +1,7 @@
 [id="cnf-best-practices-high-level-cnf-expectations"]
-= High-level CNF expectations
+= High-level workload expectations
 
-* CNFs shall be built to be cloud-native
+* Workloads shall be built to be cloud-native
 
 * Containers MUST NOT run as root (uid=0). See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#access-control-security-context-non-root-user-check[access-control-security-context-non-root-user-check]
 
@@ -9,25 +9,25 @@
 
 * Use the main CNI for all traffic - MULTUS/SRIOV/MacVLAN are for corner cases only (extreme throughput requirements, protocols that are unable to be load balanced)
 
-* CNFs should employ N+k redundancy models
+* Workloads should employ N+k redundancy models
 
-* CNFs MUST define their pod affinity/anti-affinity rules. See test cases link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#lifecycle-affinity-required-pods[lifecycle-affinity-required-pods], link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#lifecycle-pod-high-availability[lifecycle-pod-high-availability]
+* Workloads MUST define their pod affinity/anti-affinity rules. See test cases link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#lifecycle-affinity-required-pods[lifecycle-affinity-required-pods], link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#lifecycle-pod-high-availability[lifecycle-pod-high-availability]
 
-* All secondary network interfaces employed by CNFs with the use of MULTUS MUST support Dual-Stack IPv4/IPv6.
+* All secondary network interfaces employed by workloads with the use of MULTUS MUST support Dual-Stack IPv4/IPv6.
 
-* Instantiation of CNF (via Helm chart or Operators or otherwise) shall result in a fully-functional CNF ready to serve traffic, without requiring any post-instantiation configuration of system parameters
+* Instantiation of a workload (via Helm chart or Operators or otherwise) shall result in a fully-functional workload ready to serve traffic, without requiring any post-instantiation configuration of system parameters
 
-* CNFs shall implement service resilience at the application layer and not rely on individual compute availability/stability
+* Workloads shall implement service resilience at the application layer and not rely on individual compute availability/stability
 
-* CNFs shall decouple application configuration from Pods, to allow dynamic configuration updates
+* Workloads shall decouple application configuration from Pods, to allow dynamic configuration updates
 
-* CNFs shall support elasticity with dynamic scale up/down using kubernetes-native constructs such as ReplicaSets, etc. See test cases link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#lifecycle-crd-scaling[lifecycle-crd-scaling], link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#lifecycle-statefulset-scaling[lifecycle-statefulset-scaling], link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#lifecycle-deployment-scaling[lifecycle-deployment-scaling]
+* Workloads shall support elasticity with dynamic scale up/down using kubernetes-native constructs such as ReplicaSets, etc. See test cases link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#lifecycle-crd-scaling[lifecycle-crd-scaling], link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#lifecycle-statefulset-scaling[lifecycle-statefulset-scaling], link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#lifecycle-deployment-scaling[lifecycle-deployment-scaling]
 
-* CNFs shall support canary upgrades
+* Workloads shall support canary upgrades
 
-* CNFs shall self-recover from common failures like pod failure, host failure, and network failure. Kubernetes native mechanisms such as health-checks (Liveness, Readiness and Startup Probes) shall be employed at a minimum. See test cases link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#lifecycle-liveness-probe[lifecycle-liveness-probe], link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#lifecycle-readiness-probe[lifecycle-readiness-probe], link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#lifecycle-startup-probe[lifecycle-startup-probe]
+* Workloads shall self-recover from common failures like pod failure, host failure, and network failure. Kubernetes native mechanisms such as health-checks (Liveness, Readiness and Startup Probes) shall be employed at a minimum. See test cases link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#lifecycle-liveness-probe[lifecycle-liveness-probe], link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#lifecycle-readiness-probe[lifecycle-readiness-probe], link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#lifecycle-startup-probe[lifecycle-startup-probe]
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Containers must not run as root
@@ -35,7 +35,7 @@ Containers must not run as root
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#access-control-security-context-non-root-user-check[access-control-security-context-non-root-user-check]
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 All secondary interfaces (MULTUS) must support dual stack
@@ -43,10 +43,10 @@ All secondary interfaces (MULTUS) must support dual stack
 See test cases link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#networking-icmpv4-connectivity-multus[networking-icmpv4-connectivity-multus], link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#networking-icmpv6-connectivity-multus[networking-icmpv6-connectivity-multus]
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
-CNFs shall not use node selectors nor taints/tolerations to assign pod location
+Workloads shall not use node selectors nor taints/tolerations to assign pod location
 
 See test cases link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#lifecycle-pod-scheduling[lifecycle-pod-scheduling], link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#platform-alteration-tainted-node-kernel[platform-alteration-tainted-node-kernel]
 ====

--- a/modules/cnf-best-practices-ipv4-ipv6.adoc
+++ b/modules/cnf-best-practices-ipv4-ipv6.adoc
@@ -5,7 +5,7 @@ Applications should discover services via DNS by doing an AAAA and A query. If a
 
 In OpenShift Container Platform 4.7+, you can declare `ipFamilyPolicy: PreferDualStack` which will present an IPv4 and IPv6 address in the service.
 
-.CNF recommendation
+.Workload recommendation
 [IMPORTANT]
 ====
 IPv4 should only be used inside a pod when absolutely necessary.
@@ -13,7 +13,7 @@ IPv4 should only be used inside a pod when absolutely necessary.
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#networking-icmpv4-connectivity[networking-icmpv4-connectivity]
 ====
 
-.CNF recommendation
+.Workload recommendation
 [IMPORTANT]
 ====
 Services should be created as IPv6 only services wherever possible. If an application requires dual stack it should create a dual stack service.

--- a/modules/cnf-best-practices-k8s-api-versions.adoc
+++ b/modules/cnf-best-practices-k8s-api-versions.adoc
@@ -6,10 +6,10 @@ Review the Kubernetes and OpenShift API documentation:
 * link:https://docs.openshift.com/container-platform/latest/rest_api/index.html[OpenShift API index]
 * link:https://kubernetes.io/docs/reference/#[Kubernetes API reference]
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
-All CNFs must verify that they are compliant with the correct release of REST API for Kubernetes and OpenShift. Please refer to the online documentation for deprecated APIs.
+All workloads must verify that they are compliant with the correct release of REST API for Kubernetes and OpenShift. Please refer to the online documentation for deprecated APIs.
 
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#platform-alteration-ocp-lifecycle[platform-alteration-ocp-lifecycle]
 ====

--- a/modules/cnf-best-practices-linux-capabilities.adoc
+++ b/modules/cnf-best-practices-linux-capabilities.adoc
@@ -88,7 +88,7 @@ This doesn't include:
 
 All the administrative operations (except `ethtool`) mentioned above that require the `NET_ADMIN` capability should already be supported on the host by various CNIs in Openshift.
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Only userplane applications or applications using SR-IOV or Multicast can request NET_ADMIN capability
@@ -101,7 +101,7 @@ See test case link:https://github.com/test-network-function/cnf-certification-te
 
 This capability is very powerful and overloaded. It allows the application to perform a range of system administration operations to the host. So you should avoid requiring this capability in your application.
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Applications *MUST NOT* use the SYS_ADMIN Linux capability
@@ -112,7 +112,7 @@ See test case link:https://github.com/test-network-function/cnf-certification-te
 [id="cnf-best-practices-sys_nice"]
 == SYS_NICE
 
-In the case that a CNF is running on a node using the real-time kernel, SYS_NICE will be used to allow DPDK application to switch to SCHED_FIFO.
+In the case that a workload is running on a node using the real-time kernel, SYS_NICE will be used to allow DPDK application to switch to SCHED_FIFO.
 
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#access-control-sys-nice-realtime-capability[access-control-sys-nice-realtime-capability]
 

--- a/modules/cnf-best-practices-liveness-readiness-and-startup-probes.adoc
+++ b/modules/cnf-best-practices-liveness-readiness-and-startup-probes.adoc
@@ -15,7 +15,7 @@ See test cases link:https://github.com/test-network-function/cnf-certification-t
 
 [IMPORTANT]
 ====
-If the CNF is doing CPU pinning and running a DPDK process do not use exec probes (executing a command within the container); as this can pile up and eventually block the node.
+If the workload is doing CPU pinning and running a DPDK process do not use exec probes (executing a command within the container); as this can pile up and eventually block the node.
 
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#networking-dpdk-cpu-pinning-exec-probe[networking-dpdk-cpu-pinning-exec-probe]
 ====

--- a/modules/cnf-best-practices-local-storage.adoc
+++ b/modules/cnf-best-practices-local-storage.adoc
@@ -3,7 +3,7 @@
 
 Local storage is available on worker nodes for ephemeral storage only.
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Pods must not place persistent volumes in local storage.

--- a/modules/cnf-best-practices-logging.adoc
+++ b/modules/cnf-best-practices-logging.adoc
@@ -5,9 +5,9 @@ Log aggregation and analysis::
 --
 * Containers are expected to write logs to stdout. It is highly recommended that stdout/stderr leverage some standard logging format for output.
 +
-* Logs CAN be parsed to a limited extent so that specific vendor logs can be sent back to the CNF if required.
+* Logs CAN be parsed to a limited extent so that specific vendor logs can be sent back to the workload if required.
 +
-* CNFs requiring log parsing must leverage some standard logging library or format for all stdout/stderr. Examples of standard logging libraries include; `klog`, `rfc5424`, and `oslo`.
+* Workloads requiring log parsing must leverage some standard logging library or format for all stdout/stderr. Examples of standard logging libraries include; `klog`, `rfc5424`, and `oslo`.
 
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#observability-container-logging[observability-container-logging]
 --

--- a/modules/cnf-best-practices-memory-allocation.adoc
+++ b/modules/cnf-best-practices-memory-allocation.adoc
@@ -10,7 +10,7 @@ Once it has been determined how much memory is left over for the applications, q
 When the OpenShift scheduler is placing pods, it reviews the pod memory request and schedules the pod if there is a node that meets the requirements. It then imposes memory limits to ensure the pod doesn't consume more than the intended allocation. The limit can never be lower than the request.
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Vendors must supply quotas per project/namespace

--- a/modules/cnf-best-practices-monitoring.adoc
+++ b/modules/cnf-best-practices-monitoring.adoc
@@ -1,5 +1,5 @@
 [id="cnf-best-practices-monitoring"]
 = Monitoring
 
-Network Functions are expected to bring their own metrics collection functions (e.g. Prometheus) for their application specific metrics. This metrics collector will not be expected to nor able to poll platform level metric data.
+Workloads are expected to bring their own metrics collection functions (e.g. Prometheus) for their application specific metrics. This metrics collector will not be expected to nor able to poll platform level metric data.
 

--- a/modules/cnf-best-practices-multus-macvlan.adoc
+++ b/modules/cnf-best-practices-multus-macvlan.adoc
@@ -3,20 +3,20 @@
 
 SR-IOV is a specification that allows a PCIe device to appear to be multiple separate physical PCIe devices. The Performance Addon component allows you to validate SR-IOV by running DPDK, SCTP and device checking tests.
 
-SR-IOV and MACVLAN interfaces are able to be requested for protocols that do not work with the default CNI or for exceptions where a network function has not been able to move functionality onto the CNI. These are exception use cases. MULTUS interfaces will be defined by the platform operations team for the network functions which can then consume them. VLANs will be applied by the SR-IOV VF, thus the VLAN / network that the SR-IOV interface requires must be part of the request for the namespace.
+SR-IOV and MACVLAN interfaces are able to be requested for protocols that do not work with the default CNI or for exceptions where a workload has not been able to move functionality onto the CNI. These are exception use cases. MULTUS interfaces will be defined by the platform operations team for the workloads which can then consume them. VLANs will be applied by the SR-IOV VF, thus the VLAN / network that the SR-IOV interface requires must be part of the request for the namespace.
 
 For more information, see link:https://docs.openshift.com/container-platform/latest/networking/hardware_networks/about-sriov.html[About Single Root I/O Virtualization (SR-IOV) hardware networks].
 
-By configuring the SR-IOV network, CRs named `NetworkAttachmentDefinitions` are exposed by the SR-IOV Operator in the CNF namespace.
+By configuring the SR-IOV network, CRs named `NetworkAttachmentDefinitions` are exposed by the SR-IOV Operator in the workload namespace.
 
 Different names will be assigned to different Network Attachment Definitions that are namespace specific. MACVLAN versus MULTUS interfaces will be named differently to distinguish the type of device assigned to them (created by configuring SR-IOV devices via the SRIOVNetworkNodePolicy CR).
 
-From the CNF perspective, a defined set of network attachment definitions will be available in the assigned namespace to serve secondary networks for regular usage or to serve for DPDK payloads.
+From the workload perspective, a defined set of network attachment definitions will be available in the assigned namespace to serve secondary networks for regular usage or to serve for DPDK payloads.
 
-The SR-IOV devices are configured by the cluster admin, and they will be available in the namespace assigned to the CNF. The following command returns the list of secondary networks available in the namespace:
+The SR-IOV devices are configured by the cluster admin, and they will be available in the namespace assigned to the workload. The following command returns the list of secondary networks available in the namespace:
 
 [source,terminal]
 ----
-$ oc -n <cnf_namespace> get network-attachment-definitions
+$ oc -n <workload_namespace> get network-attachment-definitions
 ----
 

--- a/modules/cnf-best-practices-multus.adoc
+++ b/modules/cnf-best-practices-multus.adoc
@@ -3,7 +3,7 @@
 
 MULTUS is a meta-CNI that allows multiple CNIs that it delegates to. This allows pods to get additional interfaces beyond `eth0` via additional CNIs. Having additional CNIs for SR-IOV and MacVLAN interfaces allow for direct routing of traffic to a pod without using the pod network via additional interfaces. This capability is being delivered for use in only corner case scenarios, it is not to be used in general for all applications. Example use cases include bandwidth requirements that necessitate SR-IOV and protocols that are unable to be supported by the load balancer. The OVN based pod network should be used for every interface that can be supported from a technical standpoint.
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Unless an application has a special traffic requirement that is not supported by SPK or ovn-kubernetes CNI

--- a/modules/cnf-best-practices-no-naked-pods.adoc
+++ b/modules/cnf-best-practices-no-naked-pods.adoc
@@ -5,13 +5,13 @@ Do not use naked Pods (that is, Pods not bound to a `ReplicaSet`, or `StatefulSe
 
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#lifecycle-pod-owner-type[lifecycle-pod-owner-type]
 
-CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Applications must not depend on any single pod being online for their application to function.
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Pods must be deployed as part of a `Deployment` or `StatefulSet`.
@@ -19,7 +19,7 @@ Pods must be deployed as part of a `Deployment` or `StatefulSet`.
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#lifecycle-pod-owner-type[lifecycle-pod-owner-type]
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Pods may not be deployed in a DaemonSet.

--- a/modules/cnf-best-practices-openshift-virtualization-kubevirt.adoc
+++ b/modules/cnf-best-practices-openshift-virtualization-kubevirt.adoc
@@ -5,7 +5,7 @@ OpenShift Virtualization is generally-available for enterprise workloads, such t
 
 OpenShift Virtualization should be installed according to its documentation, and only documented supported features may be used unless an explicit exception has been granted. See link:https://docs.openshift.com/container-platform/latest/virt/about-virt.html[About OpenShift Virtualization].
 
-In order to improve overall virtualization performance and reduce CPU latency, critical VNFs can take advantage of OpenShift Virtualization's high-performance features. These can provide the VNFs with the following features:
+In order to improve overall virtualization performance and reduce CPU latency, critical workloads can take advantage of OpenShift Virtualization's high-performance features. These can provide the workloads with the following features:
 
 * link:https://docs.openshift.com/container-platform/latest/virt/virtual_machines/advanced_vm_management/virt-dedicated-resources-vm.html[Dedicated resources for virtual machines]
 

--- a/modules/cnf-best-practices-operations-that-can-not-be-executed-by-openshift.adoc
+++ b/modules/cnf-best-practices-operations-that-can-not-be-executed-by-openshift.adoc
@@ -1,7 +1,7 @@
 [id="cnf-best-practices-operations-that-can-not-be-executed-by-openshift"]
 = Operations that can not be executed by OpenShift
 
-All the CNI plugins are only invoked during pod creation and deletion. If your CNF needs perform any operations mentioned above at runtime, the `NET_ADMIN` capability is required.
+All the CNI plugins are only invoked during pod creation and deletion. If your workload needs perform any operations mentioned above at runtime, the `NET_ADMIN` capability is required.
 
 There are some other functionalities that are not currently supported by any of the OpenShift components which also require `NET_ADMIN` capability:
 

--- a/modules/cnf-best-practices-pod-exit-status.adoc
+++ b/modules/cnf-best-practices-pod-exit-status.adoc
@@ -9,7 +9,7 @@ Pods should use `terminationMessagePolicy: FallbackToLogsOnError` to summarize w
 
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#observability-termination-policy[observability-termination-policy]
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 All pods shall have a liveness, readiness and startup probes defined

--- a/modules/cnf-best-practices-pod-interaction-configuration.adoc
+++ b/modules/cnf-best-practices-pod-interaction-configuration.adoc
@@ -5,7 +5,7 @@ Pod configurations should be created in a kubernetes native manner, the most bas
 
 Interaction with a running pod should be done via `oc exec` or `oc rsh` commands. This allows API role-based access control (RBAC) to the pods and command line interaction for debugging.
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 SSH daemons must NOT be used in Openshift for pod interaction.

--- a/modules/cnf-best-practices-ports-reserved-by-openshift.adoc
+++ b/modules/cnf-best-practices-ports-reserved-by-openshift.adoc
@@ -6,7 +6,7 @@ The following ports are reserved by OpenShift and should not be used by any appl
 * `22623`
 * `22624`
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 The following ports are reserved by OpenShift and must not be used by any application: `22623`, `22624`.

--- a/modules/cnf-best-practices-refactoring.adoc
+++ b/modules/cnf-best-practices-refactoring.adoc
@@ -1,9 +1,9 @@
 [id="cnf-best-practices-refactoring"]
 = Refactoring
 
-NFs should break their software down into the smallest set of microservices as possible. Running monolithic applications inside of a container is not the operating model to be in.
+Workloads should break their software down into the smallest set of microservices as possible. Running monolithic applications inside of a container is not the operating model to be in.
 
-It is hard to move a 1000LB boulder. However, it is easy when that boulder is broken down into many pieces (pebbles). All containerized network functions (CNFs) should break apart each piece of the functions/services/processes into separate containers. These containers will still be within kubernetes pods and all of the functions that perform a single task should be within the same namespace.
+It is hard to move a 1000LB boulder. However, it is easy when that boulder is broken down into many pieces (pebbles). All workloads should break apart each piece of the functions/services/processes into separate containers. These containers will still be within kubernetes pods and all of the functions that perform a single task should be within the same namespace.
 
 There is a link:https://martinfowler.com/microservices/[quote] from Lewis and Fowler that describes this best:
 

--- a/modules/cnf-best-practices-requests-limits.adoc
+++ b/modules/cnf-best-practices-requests-limits.adoc
@@ -1,13 +1,13 @@
 [id="cnf-best-practices-requests-limits"]
 = Requests/Limits
 
-Requests and limits provide a way for a CNF developer to ensure they have adequate resources available to run the application. Requests can be made for storage, memory, CPU and so on. These requests and limits can be enforced by quotas. Quotas can be used as a way to enforce requests and limits. See link:https://docs.openshift.com/container-platform/latest/applications/quotas/quotas-setting-per-project.html[Resource quotas per project] for more information.
+Requests and limits provide a way for a workload developer to ensure they have adequate resources available to run the application. Requests can be made for storage, memory, CPU and so on. These requests and limits can be enforced by quotas. Quotas can be used as a way to enforce requests and limits. See link:https://docs.openshift.com/container-platform/latest/applications/quotas/quotas-setting-per-project.html[Resource quotas per project] for more information.
 
 Nodes can be overcommitted which can affect the strategy of request/limit implementation. For example, when you need guaranteed capacity, use quotas to enforce. In a development environment, you can overcommit where a trade-off of guaranteed performance for capacity is acceptable. Overcommitment can be done on a project, node or cluster level.
 
 See link:https://docs.openshift.com/container-platform/latest/nodes/clusters/nodes-cluster-overcommit.html[Configuring your cluster to place pods on overcommitted nodes] for more information.
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Pods must define requests and limits values for CPU and memory.

--- a/modules/cnf-best-practices-requirements-cnf-reqs.adoc
+++ b/modules/cnf-best-practices-requirements-cnf-reqs.adoc
@@ -1,5 +1,5 @@
 [id="cnf-best-practices-requirements-cnf-reqs"]
-= Requirements for CNF
+= Requirements for a workload
 
 * The application MUST declare all listening ports as containerPorts in the Pod specification it provides to Kubernetes.
 
@@ -58,13 +58,13 @@ It is recommended that container images be built utilizing Red Hat's Universal B
 
 Vendors must satisfy 3 requirements related to maintaining proper workload isolation in a containerized environment:
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Containerized workloads must work with Red Hat's restricted SCC1.
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Containerized workloads must work with Red Hat’s default SELinux context. This is meant to forbid all changes to both primary config files (SCC, SEL) and the many related files referenced by these primary files. All security configuration files must be unchanged from the vendor’s released version.
@@ -72,7 +72,7 @@ Containerized workloads must work with Red Hat’s default SELinux context. This
 See test cases link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#platform-alteration-base-image[platform-alteration-base-image], link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#platform-alteration-is-selinux-enforcing[platform-alteration-is-selinux-enforcing]
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 The container image must be secure.
@@ -116,6 +116,6 @@ Red Hat UBI images are free to vendors so there is a low barrier of entry to get
 [id="cnf-best-practices-application-dns-configuration-requirements"]
 == Application DNS configuration requirements
 
-CNFs should use the service name only as a configuration parameter for attaching to a service within your namespace, the cluster will append namespace name and kubernetes service nomenclature on behalf of the application via search string in DNS. This allows a generic name for a service that works in all clusters no matter what the namespace name is and what the cluster base FQDN is.
+Workloads should use the service name only as a configuration parameter for attaching to a service within your namespace, the cluster will append namespace name and kubernetes service nomenclature on behalf of the application via search string in DNS. This allows a generic name for a service that works in all clusters no matter what the namespace name is and what the cluster base FQDN is.
 
 For more information, see link:https://kubernetes.io/docs/concepts/services-networking/dns-pod-service[Kubernetes upstream reference for pod/service names and DNS].

--- a/modules/cnf-best-practices-security-rbac.adoc
+++ b/modules/cnf-best-practices-security-rbac.adoc
@@ -5,14 +5,14 @@ Roles / RoleBindings:: A `Role` represents a set of permissions within a particu
 
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#access-control-pod-role-bindings[access-control-pod-role-bindings]
 
-ClusterRole / ClusterRoleBinding:: A `ClusterRole` represents a set of permissions at the cluster level that can be used by multiple namespaces. The `ClusterRoleBinding` is used for granting the permissions defined in a `ClusterRole` to a user or group of users at a namespace level. Applications are not permitted to install cluster roles or create cluster role bindings. This is an administrative activity done by cluster administrators. CNFs should not use cluster roles; exceptions can be granted to allow this, however this is discouraged.
+ClusterRole / ClusterRoleBinding:: A `ClusterRole` represents a set of permissions at the cluster level that can be used by multiple namespaces. The `ClusterRoleBinding` is used for granting the permissions defined in a `ClusterRole` to a user or group of users at a namespace level. Applications are not permitted to install cluster roles or create cluster role bindings. This is an administrative activity done by cluster administrators. Workloads should not use cluster roles; exceptions can be granted to allow this, however this is discouraged.
 
 See link:https://docs.openshift.com/container-platform/4.7/authentication/using-rbac.html[Using RBAC to define and apply permissions] for more information.
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
-CNFs may not create `ClusterRole` or `ClusterRoleBinding` CRs. Only cluster administrators should create these CRs.
+Workloads may not create `ClusterRole` or `ClusterRoleBinding` CRs. Only cluster administrators should create these CRs.
 
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#access-control-cluster-role-bindings[access-control-cluster-role-bindings]
 ====

--- a/modules/cnf-best-practices-sr-iov-interface-settings.adoc
+++ b/modules/cnf-best-practices-sr-iov-interface-settings.adoc
@@ -55,7 +55,7 @@ metadata:
 spec:
   capabilities: '{ "mac": true }'
   ipam: '{}'
-  networkNamespace: <CNF-NAMESPACE>
+  networkNamespace: <WORKLOAD-NAMESPACE>
   resourceName: w1ens3f0grp2
   spoofChk: "off"
   trust: "on"
@@ -74,7 +74,7 @@ metadata:
 spec:
   capabilities: '{ "mac": true }'
   ipam: '{"type":"whereabouts","range":"FD97:0EF5:45A5:4000:00D0:0403:0000:0001/64","range_star t":"FD97:0EF5:45A5:4000:00D0:0403:0000:0001","range_end":"FD97:0EF5:45A5:4000:00D0:0403 :0000:0020","routes":[{"dst":"fd97:0ef5:45a5::/48","gw":"FD97:EF5:45A5:4000::1"}]}'
-  networkNamespace: <CNF-NAMESPACE>
+  networkNamespace: <WORKLOAD-NAMESPACE>
     resourceName: w1ens3f0grp2
     spoofChk: "off"
     trust: "on"
@@ -92,7 +92,7 @@ metadata:
   namespace: openshift-SRIOV-network-operator
 spec:
   capabilities: '{ "mac": true }'
-  ipam: '{"type": "static","addresses":[{"address":"10.120.26.5/25","gateway":"10.120.26.1"}]}' networkNamespace: <CNF-NAMESPACE>
+  ipam: '{"type": "static","addresses":[{"address":"10.120.26.5/25","gateway":"10.120.26.1"}]}' networkNamespace: <WORKLOAD-NAMESPACE>
   resourceName: w1ens3f0grp2
   spoofChk: "off"
   trust: "on"
@@ -123,16 +123,16 @@ The examples depict scenarios used within to deliver secondary network interface
 
 The actual addresses used for both whereabouts and static IPAM are managed external to the cluster.
 
-The above `SRIOVnetwork` CR will configure a network attachment definition within the CNF namespace.
+The above `SRIOVnetwork` CR will configure a network attachment definition within the workload namespace.
 
 [source,terminal]
 ----
-$ oc get net-attach-def -n <cnf_namespace>
+$ oc get net-attach-def -n <workload_namespace>
 NAME       AGE
 SRIOVnet   9d
 ----
 
-Within the CNF namespace the SR-IOV resource is consumed via a pod annotation:
+Within the workload namespace the SR-IOV resource is consumed via a pod annotation:
 
 [source,yaml]
 ----

--- a/modules/cnf-best-practices-ubi.adoc
+++ b/modules/cnf-best-practices-ubi.adoc
@@ -20,7 +20,7 @@ A set of language runtime images (PHP, Perl, Python, Ruby, Node.js) enable devel
 
 A set of associated YUM repositories/channels include RPM packages and updates that allow users to add application dependencies and rebuild UBI container images anytime they want.
 
-Red Hat UBI images are the preferred images to build virtual network functions (VNFs) with as they leverage the fully supported Red Hat ecosystem. In addition, once a VNF is standardized on a Red Hat UBI, the image can become Red Hat certified.
+Red Hat UBI images are the preferred images to build workload applications with as they leverage the fully supported Red Hat ecosystem. In addition, once a workload application is standardized on a Red Hat UBI, the image can become Red Hat certified.
 
 Red Hat UBI images are free to vendors so there is a low barrier of entry to getting started. It is possible to utilize other base images to build containers that can be run on the OpenShift platform. See link:https://redhat-connect.gitbook.io/partner-guide-for-red-hat-openshift-and-container[Partner Guide for OpenShift and Container Certification] for a view of the ease of support for containers utilizing various base images and differing levels of certification and supportability.
 

--- a/modules/cnf-best-practices-upgrade-expectations.adoc
+++ b/modules/cnf-best-practices-upgrade-expectations.adoc
@@ -3,11 +3,11 @@
 
 * The Kubernetes API deprecation policy defined in link:https://kubernetes.io/docs/reference/using-api/deprecation-policy/[Kubernetes Deprecation Policy] shall be followed.
 
-* CNFs are expected to maintain service continuity during platform upgrades, and during CNF version upgrades
+* Workloads are expected to maintain service continuity during platform upgrades, and during workload version upgrades
 
-* CNFs need to be prepared for nodes to reboot or shut down without notice
+* Workloads need to be prepared for nodes to reboot or shut down without notice
 
-* CNFs shall configure pod disruption budget appropriately to maintain service continuity during platform upgrades
+* Workloads shall configure pod disruption budget appropriately to maintain service continuity during platform upgrades
 
 * Applications should not be tied to a specific version of Kubernetes or any of its components
 
@@ -18,7 +18,7 @@ Applications MUST specify a pod disruption budget appropriately to maintain serv
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#lifecycle-pod-recreation[lifecycle-pod-recreation]
 ====
 
-.CNF requirement
+.Workload requirement
 [IMPORTANT]
 ====
 Pods that perform the same microservice and that could be disrupted if multiple members of the service are

--- a/modules/cnf-best-practices-user-plane-cnfs.adoc
+++ b/modules/cnf-best-practices-user-plane-cnfs.adoc
@@ -1,9 +1,9 @@
 [id="cnf-best-practices-user-plane-cnfs"]
-= Handling user-plane CNFs
+= Handling user-plane workloads
 
-A CNF which handles user plane traffic or latency-sensitive payloads at line rate falls into this category, such as load balancing, routing, deep packet inspection, and so on. Some of these CNFs may also need to process the packets at a lower level.
+A workload which handles user plane traffic or latency-sensitive payloads at line rate falls into this category, such as load balancing, routing, deep packet inspection, and so on. Some of these workloads may also need to process the packets at a lower level.
 
-This kind of CNF may need to:
+This kind of workload may need to:
 
 . Use SR-IOV interfaces
 
@@ -61,7 +61,7 @@ volumes:
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
-  name: cnfname
+  name: <workload_name>
 users: []
 groups: []
 priority: null


### PR DESCRIPTION
The use of "CNF Best Practices" has been replaced by "Red Hat Best Practices for Kubernetes". Also, the more generic term "workload" has replaced references to "CNFs" or "network functions".